### PR TITLE
Add performance summary reporting with color-coded P/L

### DIFF
--- a/main/engine.py
+++ b/main/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import asyncio
 import logging
+import time
 import uuid
 from typing import Dict, Optional
 from colorama import init, Fore, Style
@@ -26,9 +27,12 @@ class Engine:
 
         self.stream = LiveBinanceDataStream(cfg.symbols, host=cfg.binance_ws_host)
         self.portfolio = Portfolio(quote_ccy=cfg.quote_ccy, cash=cfg.initial_cash)
+        self.initial_equity = cfg.initial_cash
         self.paper_books: Dict[str, MarketTick] = {}
         self.slippage_bps = cfg.slippage_bps
         self.rest_exec: Optional[BinanceRestExec] = None
+        self.performance_refresh_seconds = getattr(cfg, "performance_refresh_seconds", 5.0)
+        self._last_performance_report = 0.0
         if self.live_trading:
             if not cfg.binance_api_key or not cfg.binance_api_secret:
                 raise ValueError(
@@ -77,6 +81,7 @@ class Engine:
                         f"{value_color}= {value:.2f}{Style.RESET_ALL} "
                         f"| Equity ~ {eq:.2f}"
                     )
+                    self._report_performance(force=True)
 
             if self.rest_exec:
                 try:
@@ -93,13 +98,19 @@ class Engine:
                             f"{value_color}= {value:.2f}{Style.RESET_ALL} "
                             f"| Equity ~ {eq:.2f}"
                         )
+                        self._report_performance(force=True)
                 except Exception as e:
                     log.error(f"Live order error: {e}")
 
+        self._report_performance()
+
     async def run(self):
         setup_logging()
-        async for tick in self.stream.stream():
-            await self.handle_tick(tick)
+        try:
+            async for tick in self.stream.stream():
+                await self.handle_tick(tick)
+        finally:
+            self._report_performance(force=True, final=True)
 
     def _simulate_paper_fill(self, order: OrderRequest) -> Optional[Fill]:
         book = self.paper_books.get(order.symbol)
@@ -135,3 +146,31 @@ class Engine:
         )
         self.portfolio.on_fill(fill)
         return fill
+
+    def _report_performance(self, *, force: bool = False, final: bool = False) -> None:
+        now = time.time()
+        if not force and (now - self._last_performance_report) < self.performance_refresh_seconds:
+            return
+
+        equity = self.portfolio.mark_to_market(self.stream.latest) if self.stream.latest else self.portfolio.cash
+        pnl = equity - self.initial_equity
+
+        border_color = Fore.CYAN
+        border = f"{border_color}{'=' * 60}{Style.RESET_ALL}"
+        heading_prefix = "FINAL " if final else ""
+        heading = f"{border_color}{heading_prefix}PORTFOLIO PERFORMANCE{Style.RESET_ALL}"
+        pnl_color = Fore.GREEN if pnl > 0 else (Fore.RED if pnl < 0 else Fore.WHITE)
+
+        lines = [
+            "",
+            border,
+            heading,
+            f"Initial Equity: {self.initial_equity:.2f} {self.cfg.quote_ccy}",
+            f"Current Equity: {equity:.2f} {self.cfg.quote_ccy}",
+            f"P/L: {pnl_color}{pnl:+.2f} {self.cfg.quote_ccy}{Style.RESET_ALL}",
+            border,
+            "",
+        ]
+
+        log.info("\n".join(lines))
+        self._last_performance_report = now

--- a/scripts/run_live.py
+++ b/scripts/run_live.py
@@ -14,7 +14,10 @@ def main():
     strat = Strategy(cfg.symbols, target_gross_notional=target_gross)
     eng = Engine(cfg, strat, storage, live_trading=True)
     print("Starting live trading on Binance Spot (real funds)...")
-    asyncio.run(eng.run())
+    try:
+        asyncio.run(eng.run())
+    except KeyboardInterrupt:
+        print("\nStopping live trading...\n")
 
 if __name__ == "__main__":
     main()

--- a/scripts/run_paper.py
+++ b/scripts/run_paper.py
@@ -13,7 +13,10 @@ def main():
     strat = Strategy(cfg.symbols, target_gross_notional=target_gross)
     eng = Engine(cfg, strat, storage, live_trading=False)
     print("Starting paper trading with live Binance market data...")
-    asyncio.run(eng.run())
+    try:
+        asyncio.run(eng.run())
+    except KeyboardInterrupt:
+        print("\nStopping paper trading...\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- track initial equity in the engine and periodically output a color-coded performance summary with configurable refresh cadence
- force a final performance snapshot when the engine stops running so users see green/red P&L on exit
- wrap the run scripts with KeyboardInterrupt handling for cleaner shutdown messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42fb1bda08329ba7893364abec5b6